### PR TITLE
Fixing issue #325

### DIFF
--- a/R/Plotter.R
+++ b/R/Plotter.R
@@ -644,21 +644,24 @@ Plotter <- R6::R6Class(
 
             if (is.number(image$state$y_range$ticks)) {
                 if (self$option("plot_y_ticks_exact")) {
-                    if (any(sapply(image$state$y_range[c("min", "max", "ticks")], is.na))) {
+                    if (any(vapply(image$state$y_range[c("min", "max", "ticks")], is.na, logical(1)))) {
                         self$warning <- list(
                             topic = "plotnotes",
                             message = paste("Exact ticking requires to set min and max and number of ticks"),
                             head = "warning"
                         )
-                        p <- p + ggplot2::scale_y_continuous(limits = as.numeric(image$state$y_range))
+                        p <- p + ggplot2::scale_y_continuous()
                     } else {
-                        p <- p + ggplot2::scale_y_continuous(limits = as.numeric(image$state$y_range), breaks = seq(image$state$y_range$min, image$state$y_range$max, length.out = image$state$y_range$ticks))
+                        p <- p + ggplot2::scale_y_continuous(limits = as.numeric(image$state$y_range[c("min", "max")]),
+                                                             breaks = seq(image$state$y_range$min, image$state$y_range$max,
+                                                                          length.out = image$state$y_range$ticks))
                     }
                 } else {
-                    p <- p + ggplot2::scale_y_continuous(limits = as.numeric(image$state$y_range), n.breaks = image$state$y_range$ticks)
+                    p <- p + ggplot2::scale_y_continuous(limits = as.numeric(image$state$y_range[c("min", "max")]),
+                                                         n.breaks = image$state$y_range$ticks)
                 }
             } else {
-                p <- p + ggplot2::scale_y_continuous(limits = as.numeric(image$state$y_range))
+                p <- p + ggplot2::scale_y_continuous(limits = as.numeric(image$state$y_range[c("min", "max")]))
             }
 
 

--- a/R/Plotter.R
+++ b/R/Plotter.R
@@ -754,7 +754,7 @@ Plotter <- R6::R6Class(
                 )
             } else {
                 # give a scale to the Z axis
-                p <- p + ggplot2::scale_x_continuous(limits = as.numeric(image$state$x_range))
+                p <- p + ggplot2::scale_x_continuous(limits = as.numeric(image$state$x_range[c("min", "max")]))
 
                 if (is.number(image$state$x_range$ticks)) {
                     if (self$option("plot_x_ticks_exact")) {
@@ -765,10 +765,13 @@ Plotter <- R6::R6Class(
                                 head = "warning"
                             )
                         } else {
-                            p <- p + ggplot2::scale_x_continuous(limits = as.numeric(image$state$x_range), breaks = seq(image$state$x_range$min, image$state$x_range$max, length.out = image$state$x_range$ticks))
+                            p <- p + ggplot2::scale_x_continuous(limits = as.numeric(image$state$x_range[c("min", "max")]),
+                                                                 breaks = seq(image$state$x_range$min, image$state$x_range$max,
+                                                                              length.out = image$state$x_range$ticks))
                         }
                     } else {
-                        p <- p + ggplot2::scale_x_continuous(limits = as.numeric(image$state$x_range), n.breaks = image$state$x_range$ticks)
+                        p <- p + ggplot2::scale_x_continuous(limits = as.numeric(image$state$x_range[c("min", "max")]),
+                                                             n.breaks = image$state$x_range$ticks)
                     }
                 }
             }

--- a/R/gamljglm.h.R
+++ b/R/gamljglm.h.R
@@ -41,6 +41,7 @@ gamljglmOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
             covs_scale_labels = "labels",
             export_emm = FALSE,
             export_plot = FALSE,
+            export = FALSE,
             plot_x = NULL,
             plot_z = NULL,
             plot_by = NULL,
@@ -294,7 +295,7 @@ gamljglmOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                 default=FALSE)
             private$..export <- jmvcore::OptionAction$new(
                 "export",
-                FALSE)
+                export)
             private$..plot_x <- jmvcore::OptionVariable$new(
                 "plot_x",
                 plot_x)

--- a/R/gamljgmixed.h.R
+++ b/R/gamljgmixed.h.R
@@ -41,6 +41,7 @@ gamljgmixedOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class
             export_emm = FALSE,
             export_re = FALSE,
             export_plot = FALSE,
+            export = FALSE,
             es = list(
                 "expb"),
             expb_ci = TRUE,
@@ -296,7 +297,7 @@ gamljgmixedOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class
                 default=FALSE)
             private$..export <- jmvcore::OptionAction$new(
                 "export",
-                FALSE)
+                export)
             private$..es <- jmvcore::OptionNMXList$new(
                 "es",
                 es,

--- a/R/gamljlm.h.R
+++ b/R/gamljlm.h.R
@@ -42,6 +42,7 @@ gamljlmOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
             covs_scale_labels = "labels",
             export_emm = FALSE,
             export_plot = FALSE,
+            export = FALSE,
             omnibus = "F",
             estimates_ci = TRUE,
             betas_ci = FALSE,
@@ -308,7 +309,7 @@ gamljlmOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                 default=FALSE)
             private$..export <- jmvcore::OptionAction$new(
                 "export",
-                FALSE)
+                export)
             private$..omnibus <- jmvcore::OptionList$new(
                 "omnibus",
                 omnibus,

--- a/R/gamljmixed.h.R
+++ b/R/gamljmixed.h.R
@@ -43,6 +43,7 @@ gamljmixedOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
             export_emm = FALSE,
             export_re = FALSE,
             export_plot = FALSE,
+            export = FALSE,
             plot_mode = NULL,
             plot_terms = list(
                 list()),
@@ -321,7 +322,7 @@ gamljmixedOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Class(
                 default=FALSE)
             private$..export <- jmvcore::OptionAction$new(
                 "export",
-                FALSE)
+                export)
             private$..plot_mode <- jmvcore::OptionList$new(
                 "plot_mode",
                 plot_mode,


### PR DESCRIPTION
Newer versions of ggplot2 obviously are stricter when it comes to which values can be given as scale limits. This submission explicitly extracts "min", "max" and "ticks" value from the "y_range"-list.

This fixes issue #325.